### PR TITLE
fix: change directory for test:unit command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "tap --cov test/**/*.test.js && npm run test:ts && npm run lint",
     "test:ci": "tap --cov test/**/*.test.js && npm run test:ts && npm run lint:ci",
     "test:only": "tap --only",
-    "test:unit": "tap test/*.test.js",
+    "test:unit": "tap test/**/*.test.js",
     "test:ts": "tsd",
     "lint": "standard | snazzy",
     "lint:ci": "standard",


### PR DESCRIPTION
Fixed location of test files for `test:unit` command
Error:
```
 ✖ ENOENT: no such file or directory, stat 'test/*.test.js'
```
