### PR TITLE
fix: add check if msg and meta properties are deleted and give priority to log.meta in meta object

### DIFF
--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -81,8 +81,8 @@ class CloudLogging {
     }
 
     const meta = Object.assign(
-      { severity: this.mapSeverity(log.level) },
-      log.meta // Custom property to add more meta to the LogEntry
+      log.meta, // Custom property to add more meta to the LogEntry
+      { severity: this.mapSeverity(log.level) }
     )
 
     if (log.meta) {

--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -85,14 +85,8 @@ class CloudLogging {
       log.meta // Custom property to add more meta to the LogEntry
     )
 
-    delete log.meta
-
-    if (!(delete log.meta)) {
-      const entry = this._log.entry(meta, {
-        message: 'Meta property is not deleted!'
-      })
-
-      this._log.write(entry)
+    if (log.meta) {
+      delete log.meta
     }
 
     meta.resource = Object.assign({}, this._resource, meta.resource)
@@ -104,14 +98,9 @@ class CloudLogging {
     }
 
     log.message = log.message ?? log.msg
-    delete log.msg
 
-    if (!(delete log.msg)) {
-      const entry = this._log.entry(meta, {
-        message: 'Msg property is not deleted!'
-      })
-
-      this._log.write(entry)
+    if (log.msg) {
+      delete log.msg
     }
 
     this._log.write(this._log.entry(meta, log))

--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -87,6 +87,14 @@ class CloudLogging {
 
     delete log.meta
 
+    if (!(delete log.meta)) {
+      const entry = this._log.entry(meta, {
+        message: 'Meta property is not deleted!'
+      })
+
+      this._log.write(entry)
+    }
+
     meta.resource = Object.assign({}, this._resource, meta.resource)
     meta.labels = Object.assign({}, this._defaultLabels, meta.labels)
 
@@ -97,6 +105,14 @@ class CloudLogging {
 
     log.message = log.message ?? log.msg
     delete log.msg
+
+    if (!(delete log.msg)) {
+      const entry = this._log.entry(meta, {
+        message: 'Msg property is not deleted!'
+      })
+
+      this._log.write(entry)
+    }
 
     this._log.write(this._log.entry(meta, log))
   }

--- a/test/unit/cloud_logging.test.js
+++ b/test/unit/cloud_logging.test.js
@@ -262,11 +262,15 @@ tap.test('CloudLogging#sync', root => {
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[30],
               labels: {
@@ -277,12 +281,14 @@ tap.test('CloudLogging#sync', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
-              jsonPayload: expectedLogEntry,
+              jsonPayload: expectedLog,
               logName: this.name
             })),
             expectedEntry
@@ -328,11 +334,15 @@ tap.test('CloudLogging#sync', root => {
         level: 50,
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
               labels: {
@@ -343,8 +353,10 @@ tap.test('CloudLogging#sync', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -394,11 +406,15 @@ tap.test('CloudLogging#sync', root => {
         level: 50,
         some: 'log',
         being: 'printed',
-        msg: 'being printed'
+        msg: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            logEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
               labels: {
@@ -413,8 +429,10 @@ tap.test('CloudLogging#sync', root => {
           expectedLogEntry.message = logEntry.msg
           delete expectedLogEntry.msg
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -570,7 +588,10 @@ tap.test('CloudLogging#sync', root => {
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       const httpRequestLog = {
         requestMethod: 'POST',
@@ -593,6 +614,7 @@ tap.test('CloudLogging#sync', root => {
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               httpRequest: httpRequestLog,
               severity: CloudLogging.SEVERITY_MAP[30],
@@ -604,8 +626,10 @@ tap.test('CloudLogging#sync', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -942,11 +966,15 @@ tap.test('CloudLogging#async', root => {
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'exampleTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[30],
               labels: {
@@ -957,8 +985,10 @@ tap.test('CloudLogging#async', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -1008,11 +1038,15 @@ tap.test('CloudLogging#async', root => {
         level: 50,
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
               labels: {
@@ -1023,8 +1057,10 @@ tap.test('CloudLogging#async', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -1074,11 +1110,15 @@ tap.test('CloudLogging#async', root => {
         level: 50,
         some: 'log',
         being: 'printed',
-        msg: 'being printed'
+        msg: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            logEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
               labels: {
@@ -1093,8 +1133,10 @@ tap.test('CloudLogging#async', root => {
           expectedLogEntry.message = logEntry.msg
           delete expectedLogEntry.msg
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -1250,7 +1292,10 @@ tap.test('CloudLogging#async', root => {
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       const httpRequestLog = {
         requestMethod: 'POST',
@@ -1273,6 +1318,7 @@ tap.test('CloudLogging#async', root => {
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               httpRequest: httpRequestLog,
               severity: CloudLogging.SEVERITY_MAP[30],
@@ -1284,8 +1330,10 @@ tap.test('CloudLogging#async', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {


### PR DESCRIPTION
Added a check to make sure the msg and meta properties are deleted. Did not `return` as it's not a business critical issue. Also, the coverage dropped to 91%, did not cover those lines with unit tests yet. Is this something desired, though? I am not sure about that TBH 😅 
**Context**:
If we don't delete it will end with a duplicated messge, something like `msg: 'I am a message'` and `message: 'I am a message`. If we do not delete the meta property we'll not have more custom meta in the LogEntry.