### PR TITLE
feat: Make log.meta optional

### DIFF
--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -82,9 +82,7 @@ class CloudLogging {
 
     const meta = log.meta
       ? Object.assign(log.meta, { severity: this.mapSeverity(log.level) })
-      : Object.assign(
-        { severity: this.mapSeverity(log.level) }
-      )
+      : { severity: this.mapSeverity(log.level) }
 
     if (log.meta) {
       delete log.meta

--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -80,7 +80,7 @@ class CloudLogging {
       return
     }
 
-    const meta = log.meta
+    const meta = typeof (log.meta) === 'object'
       ? Object.assign(log.meta, { severity: this.mapSeverity(log.level) })
       : { severity: this.mapSeverity(log.level) }
 

--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -81,8 +81,8 @@ class CloudLogging {
     }
 
     const meta = Object.assign(
-      { severity: this.mapSeverity(log.level) },
-      log.meta // Custom property to add more meta to the LogEntry
+      log.meta, // Custom property to add more meta to the LogEntry
+      { severity: this.mapSeverity(log.level) }
     )
 
     if (log.meta) {

--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -85,14 +85,8 @@ class CloudLogging {
       log.meta // Custom property to add more meta to the LogEntry
     )
 
-    delete log.meta
-
-    if (!(delete log.meta)) {
-      const entry = this._log.entry(meta, {
-        message: 'Meta property is not deleted!'
-      })
-
-      this._log.write(entry)
+    if (log.meta) {
+      delete log.meta
     }
 
     meta.resource = Object.assign({}, this._resource, meta.resource)
@@ -104,14 +98,9 @@ class CloudLogging {
     }
 
     log.message = log.message ?? log.msg
-    delete log.msg
 
-    if (!(delete log.msg)) {
-      const entry = this._log.entry(meta, {
-        message: 'Msg property is not deleted!'
-      })
-
-      this._log.write(entry)
+    if (log.msg) {
+      delete log.msg
     }
 
     this._log.write(this._log.entry(meta, log))

--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -87,6 +87,14 @@ class CloudLogging {
 
     delete log.meta
 
+    if (!(delete log.meta)) {
+      const entry = this._log.entry(meta, {
+        message: 'Meta property is not deleted!'
+      })
+
+      this._log.write(entry)
+    }
+
     meta.resource = Object.assign({}, this._resource, meta.resource)
     meta.labels = Object.assign({}, this._defaultLabels, meta.labels)
 
@@ -97,6 +105,14 @@ class CloudLogging {
 
     log.message = log.message ?? log.msg
     delete log.msg
+
+    if (!(delete log.msg)) {
+      const entry = this._log.entry(meta, {
+        message: 'Msg property is not deleted!'
+      })
+
+      this._log.write(entry)
+    }
 
     this._log.write(this._log.entry(meta, log))
   }

--- a/lib/cloud-logging.js
+++ b/lib/cloud-logging.js
@@ -80,10 +80,11 @@ class CloudLogging {
       return
     }
 
-    const meta = Object.assign(
-      log.meta, // Custom property to add more meta to the LogEntry
-      { severity: this.mapSeverity(log.level) }
-    )
+    const meta = log.meta
+      ? Object.assign(log.meta, { severity: this.mapSeverity(log.level) })
+      : Object.assign(
+        { severity: this.mapSeverity(log.level) }
+      )
 
     if (log.meta) {
       delete log.meta

--- a/test/unit/cloud_logging.test.js
+++ b/test/unit/cloud_logging.test.js
@@ -262,11 +262,15 @@ tap.test('CloudLogging#sync', root => {
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[30],
               labels: {
@@ -277,12 +281,14 @@ tap.test('CloudLogging#sync', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
-              jsonPayload: expectedLogEntry,
+              jsonPayload: expectedLog,
               logName: this.name
             })),
             expectedEntry
@@ -328,11 +334,15 @@ tap.test('CloudLogging#sync', root => {
         level: 50,
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
               labels: {
@@ -343,8 +353,10 @@ tap.test('CloudLogging#sync', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -394,11 +406,15 @@ tap.test('CloudLogging#sync', root => {
         level: 50,
         some: 'log',
         being: 'printed',
-        msg: 'being printed'
+        msg: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            logEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
               labels: {
@@ -413,8 +429,10 @@ tap.test('CloudLogging#sync', root => {
           expectedLogEntry.message = logEntry.msg
           delete expectedLogEntry.msg
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -570,7 +588,10 @@ tap.test('CloudLogging#sync', root => {
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       const httpRequestLog = {
         requestMethod: 'POST',
@@ -593,6 +614,7 @@ tap.test('CloudLogging#sync', root => {
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               httpRequest: httpRequestLog,
               severity: CloudLogging.SEVERITY_MAP[30],
@@ -604,8 +626,10 @@ tap.test('CloudLogging#sync', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -942,11 +966,15 @@ tap.test('CloudLogging#async', root => {
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'exampleTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[30],
               labels: {
@@ -957,8 +985,10 @@ tap.test('CloudLogging#async', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -1008,11 +1038,15 @@ tap.test('CloudLogging#async', root => {
         level: 50,
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
               labels: {
@@ -1023,8 +1057,10 @@ tap.test('CloudLogging#async', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -1074,11 +1110,15 @@ tap.test('CloudLogging#async', root => {
         level: 50,
         some: 'log',
         being: 'printed',
-        msg: 'being printed'
+        msg: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            logEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
               labels: {
@@ -1093,8 +1133,10 @@ tap.test('CloudLogging#async', root => {
           expectedLogEntry.message = logEntry.msg
           delete expectedLogEntry.msg
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -1250,7 +1292,10 @@ tap.test('CloudLogging#async', root => {
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed'
+        message: 'being printed',
+        meta: {
+          trace: 'testTrace-123'
+        }
       }
       const httpRequestLog = {
         requestMethod: 'POST',
@@ -1273,6 +1318,7 @@ tap.test('CloudLogging#async', root => {
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
             {
               httpRequest: httpRequestLog,
               severity: CloudLogging.SEVERITY_MAP[30],
@@ -1284,8 +1330,10 @@ tap.test('CloudLogging#async', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
           t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
+          t.same(log, expectedLog)
 
           return (
             (expectedEntry = Object.assign({}, meta, {

--- a/test/unit/cloud_logging.test.js
+++ b/test/unit/cloud_logging.test.js
@@ -255,7 +255,74 @@ tap.test('CloudLogging#sync', root => {
       sync: true
     }
 
-    nested.plan(9)
+    nested.plan(10)
+
+    nested.test('Should discard non-object meta and parse a line correctly', async t => {
+      let expectedEntry
+      const expectedLogEntry = {
+        some: 'log',
+        being: 'printed',
+        message: 'being printed',
+        meta: ''
+      }
+
+      class LogMock extends BaseLogMock {
+        entry (meta, log) {
+          const expectedMeta = Object.assign(
+            {
+              severity: CloudLogging.SEVERITY_MAP[30],
+              labels: {
+                logger: 'pino',
+                agent: 'cloud_pine'
+              }
+            },
+            { resource: Object.assign({ type: 'global' }, detectedResource) }
+          )
+
+          t.same(meta, expectedMeta)
+          t.same(log, expectedLogEntry)
+
+          return (
+            (expectedEntry = Object.assign({}, meta, {
+              jsonPayload: expectedLogEntry,
+              logName: this.name
+            })),
+            expectedEntry
+          )
+        }
+
+        write (entry) {
+          t.same(entry, expectedEntry)
+        }
+      }
+
+      class LoggingMock extends BaseLoggingMock {
+        setProjectId () {
+          return Promise.resolve()
+        }
+
+        setDetectedResource () {
+          this.detectedResource = detectedResource
+          return Promise.resolve()
+        }
+
+        logSync (name) {
+          return new LogMock(name)
+        }
+      }
+
+      const { CloudLogging } = t.mock('../../lib/cloud-logging', {
+        '@google-cloud/logging': { Logging: LoggingMock }
+      })
+
+      t.plan(3)
+
+      const instance = new CloudLogging(logName, defaultOptions)
+
+      await instance.init()
+
+      instance.parseLine(JSON.stringify(expectedLogEntry))
+    })
 
     nested.test('Should parse a line correctly', async t => {
       let expectedEntry
@@ -1179,73 +1246,7 @@ tap.test('CloudLogging#async', root => {
       }
     }
 
-    nested.plan(8)
-
-    nested.test('Should discard non-object meta and parse a line correctly', async t => {
-      let expectedEntry
-      const expectedLogEntry = {
-        some: 'log',
-        being: 'printed',
-        message: 'being printed',
-        meta: false
-      }
-      class LogMock extends BaseLogMock {
-        entry (meta, log) {
-          const expectedMeta = Object.assign(
-            {
-              severity: CloudLogging.SEVERITY_MAP[30],
-              labels: {
-                logger: 'pino',
-                agent: 'cloud_pine'
-              }
-            },
-            { resource: Object.assign({ type: 'global' }, detectedResource) }
-          )
-
-          t.same(meta, expectedMeta)
-          t.same(log, expectedLogEntry)
-
-          return (
-            (expectedEntry = Object.assign({}, meta, {
-              jsonPayload: expectedLogEntry,
-              logName: this.name
-            })),
-            expectedEntry
-          )
-        }
-
-        write (entry) {
-          t.same(entry, expectedEntry)
-        }
-      }
-
-      class LoggingMock extends BaseLoggingMock {
-        setProjectId () {
-          return Promise.resolve()
-        }
-
-        setDetectedResource () {
-          this.detectedResource = detectedResource
-          return Promise.resolve()
-        }
-
-        log (name) {
-          return new LogMock(name)
-        }
-      }
-
-      const { CloudLogging } = t.mock('../../lib/cloud-logging', {
-        '@google-cloud/logging': { Logging: LoggingMock }
-      })
-
-      t.plan(3)
-
-      const instance = new CloudLogging(logName, defaultOptions)
-
-      await instance.init()
-
-      instance.parseLine(JSON.stringify(expectedLogEntry))
-    })
+    nested.plan(9)
 
     nested.test('Should parse a line correctly', async t => {
       let expectedEntry
@@ -1418,6 +1419,138 @@ tap.test('CloudLogging#async', root => {
 
           t.same(meta, expectedMeta)
           t.same(log, expectedLog)
+
+          return (
+            (expectedEntry = Object.assign({}, meta, {
+              jsonPayload: expectedLogEntry,
+              logName: this.name
+            })),
+            expectedEntry
+          )
+        }
+
+        write (entry) {
+          t.same(entry, expectedEntry)
+        }
+      }
+
+      class LoggingMock extends BaseLoggingMock {
+        setProjectId () {
+          return Promise.resolve()
+        }
+
+        setDetectedResource () {
+          this.detectedResource = detectedResource
+          return Promise.resolve()
+        }
+
+        log (name) {
+          return new LogMock(name)
+        }
+      }
+
+      const { CloudLogging } = t.mock('../../lib/cloud-logging', {
+        '@google-cloud/logging': { Logging: LoggingMock }
+      })
+
+      t.plan(3)
+
+      const instance = new CloudLogging(logName, defaultOptions)
+
+      await instance.init()
+
+      instance.parseLine(JSON.stringify(expectedLogEntry))
+    })
+
+    nested.test('Should discard non-object meta and parse a line correctly', async t => {
+      let expectedEntry
+      const expectedLogEntry = {
+        some: 'log',
+        being: 'printed',
+        message: 'being printed',
+        meta: false
+      }
+      class LogMock extends BaseLogMock {
+        entry (meta, log) {
+          const expectedMeta = Object.assign(
+            {
+              severity: CloudLogging.SEVERITY_MAP[30],
+              labels: {
+                logger: 'pino',
+                agent: 'cloud_pine'
+              }
+            },
+            { resource: Object.assign({ type: 'global' }, detectedResource) }
+          )
+
+          t.same(meta, expectedMeta)
+          t.same(log, expectedLogEntry)
+
+          return (
+            (expectedEntry = Object.assign({}, meta, {
+              jsonPayload: expectedLogEntry,
+              logName: this.name
+            })),
+            expectedEntry
+          )
+        }
+
+        write (entry) {
+          t.same(entry, expectedEntry)
+        }
+      }
+
+      class LoggingMock extends BaseLoggingMock {
+        setProjectId () {
+          return Promise.resolve()
+        }
+
+        setDetectedResource () {
+          this.detectedResource = detectedResource
+          return Promise.resolve()
+        }
+
+        log (name) {
+          return new LogMock(name)
+        }
+      }
+
+      const { CloudLogging } = t.mock('../../lib/cloud-logging', {
+        '@google-cloud/logging': { Logging: LoggingMock }
+      })
+
+      t.plan(3)
+
+      const instance = new CloudLogging(logName, defaultOptions)
+
+      await instance.init()
+
+      instance.parseLine(JSON.stringify(expectedLogEntry))
+    })
+
+    nested.test('Should discard non-object meta and parse a line correctly', async t => {
+      let expectedEntry
+      const expectedLogEntry = {
+        some: 'log',
+        being: 'printed',
+        message: 'being printed',
+        meta: ''
+      }
+      class LogMock extends BaseLogMock {
+        entry (meta, log) {
+          const expectedMeta = Object.assign(
+            {
+              severity: CloudLogging.SEVERITY_MAP[30],
+              labels: {
+                logger: 'pino',
+                agent: 'cloud_pine'
+              }
+            },
+            { resource: Object.assign({ type: 'global' }, detectedResource) }
+          )
+
+          t.same(meta, expectedMeta)
+          t.same(log, expectedLogEntry)
 
           return (
             (expectedEntry = Object.assign({}, meta, {

--- a/test/unit/cloud_logging.test.js
+++ b/test/unit/cloud_logging.test.js
@@ -255,7 +255,7 @@ tap.test('CloudLogging#sync', root => {
       sync: true
     }
 
-    nested.plan(8)
+    nested.plan(9)
 
     nested.test('Should parse a line correctly', async t => {
       let expectedEntry
@@ -432,6 +432,73 @@ tap.test('CloudLogging#sync', root => {
           return (
             (expectedEntry = Object.assign({}, meta, {
               jsonPayload: expectedLog,
+              logName: this.name
+            })),
+            expectedEntry
+          )
+        }
+
+        write (entry) {
+          t.same(entry, expectedEntry)
+        }
+      }
+
+      class LoggingMock extends BaseLoggingMock {
+        setProjectId () {
+          return Promise.resolve()
+        }
+
+        setDetectedResource () {
+          this.detectedResource = detectedResource
+          return Promise.resolve()
+        }
+
+        logSync (name) {
+          return new LogMock(name)
+        }
+      }
+
+      const { CloudLogging } = t.mock('../../lib/cloud-logging', {
+        '@google-cloud/logging': { Logging: LoggingMock }
+      })
+
+      t.plan(3)
+
+      const instance = new CloudLogging(logName, defaultOptions)
+
+      await instance.init()
+
+      instance.parseLine(JSON.stringify(expectedLogEntry))
+    })
+
+    nested.test('Should discard non-object meta and parse a line correctly', async t => {
+      let expectedEntry
+      const expectedLogEntry = {
+        some: 'log',
+        being: 'printed',
+        message: 'being printed',
+        meta: false
+      }
+
+      class LogMock extends BaseLogMock {
+        entry (meta, log) {
+          const expectedMeta = Object.assign(
+            {
+              severity: CloudLogging.SEVERITY_MAP[30],
+              labels: {
+                logger: 'pino',
+                agent: 'cloud_pine'
+              }
+            },
+            { resource: Object.assign({ type: 'global' }, detectedResource) }
+          )
+
+          t.same(meta, expectedMeta)
+          t.same(log, expectedLogEntry)
+
+          return (
+            (expectedEntry = Object.assign({}, meta, {
+              jsonPayload: expectedLogEntry,
               logName: this.name
             })),
             expectedEntry
@@ -1112,7 +1179,73 @@ tap.test('CloudLogging#async', root => {
       }
     }
 
-    nested.plan(7)
+    nested.plan(8)
+
+    nested.test('Should discard non-object meta and parse a line correctly', async t => {
+      let expectedEntry
+      const expectedLogEntry = {
+        some: 'log',
+        being: 'printed',
+        message: 'being printed',
+        meta: false
+      }
+      class LogMock extends BaseLogMock {
+        entry (meta, log) {
+          const expectedMeta = Object.assign(
+            {
+              severity: CloudLogging.SEVERITY_MAP[30],
+              labels: {
+                logger: 'pino',
+                agent: 'cloud_pine'
+              }
+            },
+            { resource: Object.assign({ type: 'global' }, detectedResource) }
+          )
+
+          t.same(meta, expectedMeta)
+          t.same(log, expectedLogEntry)
+
+          return (
+            (expectedEntry = Object.assign({}, meta, {
+              jsonPayload: expectedLogEntry,
+              logName: this.name
+            })),
+            expectedEntry
+          )
+        }
+
+        write (entry) {
+          t.same(entry, expectedEntry)
+        }
+      }
+
+      class LoggingMock extends BaseLoggingMock {
+        setProjectId () {
+          return Promise.resolve()
+        }
+
+        setDetectedResource () {
+          this.detectedResource = detectedResource
+          return Promise.resolve()
+        }
+
+        log (name) {
+          return new LogMock(name)
+        }
+      }
+
+      const { CloudLogging } = t.mock('../../lib/cloud-logging', {
+        '@google-cloud/logging': { Logging: LoggingMock }
+      })
+
+      t.plan(3)
+
+      const instance = new CloudLogging(logName, defaultOptions)
+
+      await instance.init()
+
+      instance.parseLine(JSON.stringify(expectedLogEntry))
+    })
 
     nested.test('Should parse a line correctly', async t => {
       let expectedEntry

--- a/test/unit/cloud_logging.test.js
+++ b/test/unit/cloud_logging.test.js
@@ -255,22 +255,18 @@ tap.test('CloudLogging#sync', root => {
       sync: true
     }
 
-    nested.plan(7)
+    nested.plan(8)
 
     nested.test('Should parse a line correctly', async t => {
       let expectedEntry
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed',
-        meta: {
-          trace: 'testTrace-123'
-        }
+        message: 'being printed'
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
-            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[30],
               labels: {
@@ -281,14 +277,12 @@ tap.test('CloudLogging#sync', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
-          const { meta: _meta, ...expectedLog } = expectedLogEntry
-
           t.same(meta, expectedMeta)
-          t.same(log, expectedLog)
+          t.same(log, expectedLogEntry)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
-              jsonPayload: expectedLog,
+              jsonPayload: expectedLogEntry,
               logName: this.name
             })),
             expectedEntry
@@ -334,6 +328,71 @@ tap.test('CloudLogging#sync', root => {
         level: 50,
         some: 'log',
         being: 'printed',
+        message: 'being printed'
+      }
+      class LogMock extends BaseLogMock {
+        entry (meta, log) {
+          const expectedMeta = Object.assign(
+            {
+              severity: CloudLogging.SEVERITY_MAP[50],
+              labels: {
+                logger: 'pino',
+                agent: 'cloud_pine'
+              }
+            },
+            { resource: Object.assign({ type: 'global' }, detectedResource) }
+          )
+
+          t.same(meta, expectedMeta)
+          t.same(log, expectedLogEntry)
+
+          return (
+            (expectedEntry = Object.assign({}, meta, {
+              jsonPayload: expectedLogEntry,
+              logName: this.name
+            })),
+            expectedEntry
+          )
+        }
+
+        write (entry) {
+          t.same(entry, expectedEntry)
+        }
+      }
+
+      class LoggingMock extends BaseLoggingMock {
+        setProjectId () {
+          return Promise.resolve()
+        }
+
+        setDetectedResource () {
+          this.detectedResource = detectedResource
+          return Promise.resolve()
+        }
+
+        logSync (name) {
+          return new LogMock(name)
+        }
+      }
+
+      const { CloudLogging } = t.mock('../../lib/cloud-logging', {
+        '@google-cloud/logging': { Logging: LoggingMock }
+      })
+
+      t.plan(3)
+
+      const instance = new CloudLogging(logName, defaultOptions)
+
+      await instance.init()
+
+      instance.parseLine(JSON.stringify(expectedLogEntry))
+    })
+
+    nested.test('Should parse a line correctly (custom meta)', async t => {
+      let expectedEntry
+      const expectedLogEntry = {
+        some: 'log',
+        being: 'printed',
         message: 'being printed',
         meta: {
           trace: 'testTrace-123'
@@ -344,7 +403,7 @@ tap.test('CloudLogging#sync', root => {
           const expectedMeta = Object.assign(
             expectedLogEntry.meta,
             {
-              severity: CloudLogging.SEVERITY_MAP[50],
+              severity: CloudLogging.SEVERITY_MAP[30],
               labels: {
                 logger: 'pino',
                 agent: 'cloud_pine'
@@ -360,7 +419,7 @@ tap.test('CloudLogging#sync', root => {
 
           return (
             (expectedEntry = Object.assign({}, meta, {
-              jsonPayload: expectedLogEntry,
+              jsonPayload: expectedLog,
               logName: this.name
             })),
             expectedEntry
@@ -1041,22 +1100,18 @@ tap.test('CloudLogging#async', root => {
       }
     }
 
-    nested.plan(6)
+    nested.plan(7)
 
     nested.test('Should parse a line correctly', async t => {
       let expectedEntry
       const expectedLogEntry = {
         some: 'log',
         being: 'printed',
-        message: 'being printed',
-        meta: {
-          trace: 'exampleTrace-123'
-        }
+        message: 'being printed'
       }
       class LogMock extends BaseLogMock {
         entry (meta, log) {
           const expectedMeta = Object.assign(
-            expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[30],
               labels: {
@@ -1067,10 +1122,8 @@ tap.test('CloudLogging#async', root => {
             { resource: Object.assign({ type: 'global' }, detectedResource) }
           )
 
-          const { meta: _meta, ...expectedLog } = expectedLogEntry
-
           t.same(meta, expectedMeta)
-          t.same(log, expectedLog)
+          t.same(log, expectedLogEntry)
 
           return (
             (expectedEntry = Object.assign({}, meta, {
@@ -1131,6 +1184,77 @@ tap.test('CloudLogging#async', root => {
             expectedLogEntry.meta,
             {
               severity: CloudLogging.SEVERITY_MAP[50],
+              labels: {
+                logger: 'pino',
+                agent: 'cloud_pine'
+              }
+            },
+            { resource: Object.assign({ type: 'global' }, detectedResource) }
+          )
+
+          const { meta: _meta, ...expectedLog } = expectedLogEntry
+
+          t.same(meta, expectedMeta)
+          t.same(log, expectedLog)
+
+          return (
+            (expectedEntry = Object.assign({}, meta, {
+              jsonPayload: expectedLogEntry,
+              logName: this.name
+            })),
+            expectedEntry
+          )
+        }
+
+        write (entry) {
+          t.same(entry, expectedEntry)
+        }
+      }
+
+      class LoggingMock extends BaseLoggingMock {
+        setProjectId () {
+          return Promise.resolve()
+        }
+
+        setDetectedResource () {
+          this.detectedResource = detectedResource
+          return Promise.resolve()
+        }
+
+        log (name) {
+          return new LogMock(name)
+        }
+      }
+
+      const { CloudLogging } = t.mock('../../lib/cloud-logging', {
+        '@google-cloud/logging': { Logging: LoggingMock }
+      })
+
+      t.plan(3)
+
+      const instance = new CloudLogging(logName, defaultOptions)
+
+      await instance.init()
+
+      instance.parseLine(JSON.stringify(expectedLogEntry))
+    })
+
+    nested.test('Should parse a line correctly (custom meta)', async t => {
+      let expectedEntry
+      const expectedLogEntry = {
+        some: 'log',
+        being: 'printed',
+        message: 'being printed',
+        meta: {
+          trace: 'exampleTrace-123'
+        }
+      }
+      class LogMock extends BaseLogMock {
+        entry (meta, log) {
+          const expectedMeta = Object.assign(
+            expectedLogEntry.meta,
+            {
+              severity: CloudLogging.SEVERITY_MAP[30],
               labels: {
                 logger: 'pino',
                 agent: 'cloud_pine'


### PR DESCRIPTION
Currently the log.meta property is not optional, this PR aims to make it optional, from:
```    const meta = Object.assign(
      log.meta, // Optional custom property to add more meta to the LogEntry
      { severity: this.mapSeverity(log.level) }
    )
```
to:
```
    const meta = log.meta
      ? Object.assign(log.meta, { severity: this.mapSeverity(log.level) })
      : Object.assign(
        { severity: this.mapSeverity(log.level) }
      )
```
+ added unit tests